### PR TITLE
enable call parse method by CronConfigParser.call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Or install it yourself as:
 
 ## Usage
 
-You can parse the cron configuration for readability with `CronConfigParser::Parser.call`.
+You can parse the cron configuration for readability with `CronConfigParser.call`.
 
 ``` ruby
-CronConfigParser::Parser.call('00 5 * * * Asia/Tokyo')
+CronConfigParser.call('00 5 * * * Asia/Tokyo')
 => #<CronConfigParser::CronConfig:0x00007fa4f492e820
  @days=["*"],
  @hours=["5"],
@@ -36,7 +36,7 @@ enable check configured properties.
 
 ``` ruby
 # return false if configured nil or '*'
-config = CronConfigParser::Parser.call('00 5 * * * Asia/Tokyo')
+config = CronConfigParser.call('00 5 * * * Asia/Tokyo')
 config.minutes_configured?
 => true
 config.days_configured?
@@ -46,7 +46,7 @@ config.days_configured?
 enable check next execute time.
 
 ``` ruby
-config = CronConfigParser::Parser.call('00 5 * * * Asia/Tokyo')
+config = CronConfigParser.call('00 5 * * * Asia/Tokyo')
 config.next_execute_at
 => 2019-05-23 05:00:00 +0900
 ```
@@ -56,15 +56,15 @@ If the config is invalid, Config::SyntaxError or Config::RequiredError is raised
 
 ``` ruby
 # not configured require property.
-CronConfigParser::Parser.call('00 5,13 * * ')
+CronConfigParser.call('00 5,13 * * ')
 => CronConfigParser::ConfigRequiredError
 
 # configured invalid property.
-CronConfigParser::Parser.call('00 5,a * * * Asia/Tokyo')
+CronConfigParser.call('00 5,a * * * Asia/Tokyo')
 => CronConfigParser::ConfigSyntaxError
 
 # this check is Invalidationable.
-CronConfigParser::Parser.call('00 5,a * * * Asia/Tokyo', validation: false)
+CronConfigParser.call('00 5,a * * * Asia/Tokyo', validation: false)
 => #<CronConfigParser::CronConfig:0x00007fcedf09cdf0
  @days=["*"],
  @hours=["5", "a"],

--- a/lib/cron_config_parser.rb
+++ b/lib/cron_config_parser.rb
@@ -2,6 +2,12 @@ require "cron_config_parser/version"
 require 'active_support/all'
 
 module CronConfigParser
+  def self.call(cron_config, validation: true)
+    Parser.call(cron_config, validation: true)
+  end
+
+  private
+
   class Parser
     def self.call(cron_config, validation: true)
       new(cron_config, validation: validation).call

--- a/spec/cron_config_parser_spec.rb
+++ b/spec/cron_config_parser_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe CronConfigParser do
     expect(CronConfigParser::VERSION).not_to be nil
   end
 
+  describe '.call' do
+    let(:result) { CronConfigParser.call('00 5 * * * Asia/Tokyo') }
+
+    it 'return CronConfig object.' do
+      expect(result.class).to eq CronConfigParser::CronConfig
+    end
+  end
+
   describe 'Parser' do
     describe '.call' do
       let(:result) { CronConfigParser::Parser.call('00 5 * * * Asia/Tokyo') }


### PR DESCRIPTION
enable call parse method by CronConfigParser.call

``` ruby
CronConfigParser.call('00 5 * * * Asia/Tokyo')

=> #<CronConfigParser::CronConfig:0x00007fadcea4a0a0
 @days=["*"],
 @hours=["*"],
 @minutes=["*"],
 @months=["*"],
 @timezone=nil,
 @wdays=["*"]>
```